### PR TITLE
Auto-locate Unity install

### DIFF
--- a/UnityScript2CSharp/CommandLineArguments.cs
+++ b/UnityScript2CSharp/CommandLineArguments.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CommandLine;
 
@@ -5,7 +6,7 @@ namespace UnityScript2CSharp
 {
     public class CommandLineArguments
     {
-        [Option('u', "unityPath", Required = true, HelpText = "Unity installation path.")]
+        [Option('u', "unityPath", Required = false, HelpText = "Unity installation path. By default the tool will attempt to automatically locate your Unity install.")]
         public string UnityPath { get; set; }
 
         [Option('p', "projectPath", Required = true, HelpText = "Path of project to be converted.")]

--- a/UnityScript2CSharp/Program.cs
+++ b/UnityScript2CSharp/Program.cs
@@ -99,9 +99,35 @@ namespace UnityScript2CSharp
             if (hasErrors)
                 return false;
 
+            if (string.IsNullOrWhiteSpace(options.Value.UnityPath))
+            {
+                switch (Environment.OSVersion.Platform)
+                {
+                    case PlatformID.MacOSX:
+                    case PlatformID.Unix:
+                    {
+                        options.Value.UnityPath = "/Applications/Unity/Unity.app";
+                        break;
+                    }
+                    default:
+                    {
+                        options.Value.UnityPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Unity");
+                        if (!Directory.Exists(options.Value.UnityPath))
+                            options.Value.UnityPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Unity");
+                        break;
+                    }
+                }
+            }
+
+            if (!Directory.Exists(options.Value.UnityPath))
+            {
+                Console.WriteLine($"Couldn't find Unity install at {options.Value.UnityPath}. You need to manually specify the path to your Unity install's root folder using the --unityPath option.");
+                return false;
+            }
+
             // For some reason the command line parser is not detecting missing required arguments if we have multiple options
             // marked as required.
-            if (string.IsNullOrWhiteSpace(options.Value.UnityPath) || string.IsNullOrWhiteSpace(options.Value.ProjectPath))
+            if (string.IsNullOrWhiteSpace(options.Value.ProjectPath))
             {
                 Console.WriteLine(HelpText.AutoBuild(options).ToString());
                 return false;

--- a/UnityScript2CSharp/UnityScript2CSharp.csproj
+++ b/UnityScript2CSharp/UnityScript2CSharp.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
If the --unityPath argument is not supplied, attempt to automatically
locate the Unity install by looking at the default install locations for
the Editor.