### PR TITLE
Fixed issues when running with Unity 2018.1

### DIFF
--- a/EditorIntegration/Assets/UnityScript2CSharp/Editor/UnityScript2CSharpRunner.cs
+++ b/EditorIntegration/Assets/UnityScript2CSharp/Editor/UnityScript2CSharpRunner.cs
@@ -2,15 +2,20 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using Assets.Editor;
 using UnityEditor;
-using UnityEditor.Compilation;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using Application = UnityEngine.Application;
 using Debug = UnityEngine.Debug;
+
+#if UNITY_2017_3_OR_NEWER        
+
+using System.Linq;
+using UnityEngine.SceneManagement;
+using UnityEditor.Compilation;
+
+#endif
 
 [Serializable]
 public class UnityScript2CSharpRunner : UnityEditor.EditorWindow
@@ -248,7 +253,8 @@ public class UnityScript2CSharpRunner : UnityEditor.EditorWindow
 
             var referencedAssemblies = CompilationPipeline.GetAssemblies()
                                             .SelectMany(a => a.compiledAssemblyReferences)
-                                            .Where(a => !a.Contains(unityInstallPath) || a.Contains("UnityExtensions"));
+                                            .Where(a => !a.Contains(unityInstallPath) || a.Contains("UnityExtensions"))
+                                            .Distinct(StringComparer.InvariantCultureIgnoreCase);
             
             foreach (var assemblyPath in referencedAssemblies)
             {

--- a/EditorIntegration/Assets/UnityScript2CSharp/Editor/UnityScript2CSharpRunner.cs
+++ b/EditorIntegration/Assets/UnityScript2CSharp/Editor/UnityScript2CSharpRunner.cs
@@ -223,7 +223,7 @@ public class UnityScript2CSharpRunner : UnityEditor.EditorWindow
         if (retCode == 0)
             Debug.Log("UnityScript2CSharp converter finished (You can remove '" + ConverterPackageFolder + "' if you dont plan to run the converter in ths project again).\r\n\r\n" + File.ReadAllText(logFilePath));
         else            
-            Debug.Log("UnityScript2CSharp was not able to convert your project:.\r\n\r\n" + File.ReadAllText(logFilePath));
+            Debug.Error("UnityScript2CSharp was not able to convert your project:.\r\n\r\n" + File.ReadAllText(logFilePath));
 
 
         var prevFilePath = logFilePath + ".prev";

--- a/UnityScript2CSharp/Program.cs
+++ b/UnityScript2CSharp/Program.cs
@@ -234,16 +234,8 @@ namespace UnityScript2CSharp
         private static void AppendUnityAssembliesReferences(string unityAssembliesRootPath, List<string> references)
         {
             var modularizedUnityEngineFolder = Path.Combine(unityAssembliesRootPath, "UnityEngine");
-            if (Directory.Exists(modularizedUnityEngineFolder))
-            {
-                foreach (var assemblyPath in Directory.GetFiles(modularizedUnityEngineFolder, "*.dll"))
-                {
-                    references.Add(assemblyPath);
-                }
-            }
-            else
-                references.Add(Path.Combine(unityAssembliesRootPath, "UnityEngine.dll"));
-
+            
+            references.Add(Path.Combine(unityAssembliesRootPath, "UnityEngine.dll"));
             references.Add(Path.Combine(unityAssembliesRootPath, "UnityEditor.dll"));
         }
 
@@ -330,6 +322,13 @@ namespace UnityScript2CSharp
             IEnumerable<string> references = AssemblyReferencesFor(args, assemblyType);
 
             Console.WriteLine("Converting '{0}' ({1} scripts)", assemblyType, scripts.Count);
+
+            if (args.Verbose)
+            {
+                Console.WriteLine("Referenced assemblies:");
+                foreach(var r in references)
+                    System.Console.WriteLine($"\t{r}");
+            }
 
             Action<string, string, int> handler = (scriptPath, context, unsupportedCount) => HandleConvertedScript(scriptPath, context, args.RemoveOriginalFiles, args.Verbose, unsupportedCount);
             if (args.DryRun)

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Before running the conversion tool:
 
 1. Keep in mind that you'll have best results (i.e, a smoother conversion process) if your UnityScripts have  *#pragma strict* applied to them.
 
-1. Launch Unity editor (**preferably, 2018.2**) and make sure you allow APIUpdater to run and update any obsolete API usages. This is necessary to avoid compilation errors during the conversion.
+1. Launch Unity editor (**preferably, 2018.1**) and make sure you allow APIUpdater to run and update any obsolete API usages. This is necessary to avoid compilation errors during the conversion.
 
 Next step is to run the converter. For that we recomend trying the _Editor Unity Package Integration_ first:
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Before running the conversion tool:
 
 1. Keep in mind that you'll have best results (i.e, a smoother conversion process) if your UnityScripts have  *#pragma strict* applied to them.
 
-1. Launch Unity editor (**preferably, 2018.1**) and make sure you allow APIUpdater to run and update any obsolete API usages. This is necessary to avoid compilation errors during the conversion.
+1. Launch Unity editor (**2017.3 ~ 2018.1 versions are supported; 2018.1 is recommended**) and make sure you allow APIUpdater to run and update any obsolete API usages. This is necessary to avoid compilation errors during the conversion.
 
 Next step is to run the converter. For that we recomend trying the _Editor Unity Package Integration_ first:
 


### PR DESCRIPTION
Main issue was a failure due to us parser complaining about Unity types being declared in multiple assemblies (UnityEngine.CoreModule / UnityEngine for instance)