### PR TITLE
Fixes some issues with the converter

### DIFF
--- a/UnityScript2CSharp.Tests/Tests.cs
+++ b/UnityScript2CSharp.Tests/Tests.cs
@@ -223,7 +223,7 @@ namespace UnityScript2CSharp.Tests
         }
 
         [Test]
-        public void Locals_Infered_Type()
+        public void Locals_Inferred_Type()
         {
             var sourceFiles = SingleSourceFor("locals_inferred.js", "function F() { var i = 2; }");
             var expectedConvertedContents = SingleSourceFor("locals_inferred.cs", DefaultGeneratedClass + "locals_inferred : MonoBehaviour { public virtual void F() { int i = 2; } }");
@@ -557,7 +557,7 @@ namespace UnityScript2CSharp.Tests
 
         [TestCase("", TestName = "No Start Method")]
         [TestCase(" System.Console.WriteLine(\"Within Start\");", TestName = "With Start Method")]
-        public void Glocal_Statements_Are_Injected_In_Begin_Of_Start(string startBody)
+        public void Global_Statements_Are_Injected_In_Begin_Of_Start(string startBody)
         {
             var start = startBody.Length != 0 ? $"function Start() {{ {startBody} }}" : "";
             var sourceFiles = new[] { new SourceFile { FileName = "global_statements.js", Contents = $"System.Console.WriteLine(\"Foo\"); {start}" } };
@@ -570,7 +570,7 @@ namespace UnityScript2CSharp.Tests
         [TestCase("var f = function() { return 2; }", "Func<int> f = () => { return 2; } ", TestName = "Explicit Return")]
         [TestCase("var f = function(i) i % 2", "Func<object,object> f = (object i) => { return ((int) i) % 2; } ", TestName = "Inferred Parameter Type")]
         [TestCase("var f = function(i) { return i + 1; }", "Func<object,object> f = (object i) => { return ((int) i) + 1; } ", TestName = "Inferred Parameter 2")]
-        [TestCase("var f = function(i:int) i % 2", "Func<intint> f = (int i) => { return i % 2; } ", TestName = "Explicit Parameter Type")]
+        [TestCase("var f = function(i:int) i % 2", "Func<int,int> f = (int i) => { return i % 2; } ", TestName = "Explicit Parameter Type")]
         [TestCase("var f = function(i) { var x : int = i; return x + 1; }", "Func<object,int> f = (object i) => { int x = (int) i; return x + 1; } ", TestName = "Inferred Parameter Explicit Type")]   // Object means we infer the lambda parameter type incorrecly
         [TestCase("var f = function(i) i % 2; F( f(1) )", "Func<object,object> f = (object i) => { return ((int) i) % 2; } ; this.F((int) f(1))", TestName = "Inferred parameter with specific argument type")]  // Object means we infer the lambda parameter type incorrecly
         public void Lambda_Expressions(string functionDecl, string csFunctionDecl)
@@ -757,6 +757,15 @@ namespace UnityScript2CSharp.Tests
         }
 
         [Test]
+        public void Test_Members()
+        {
+            var sourceFiles = new[] { new SourceFile { FileName = "string_members.js", Contents = "function F(s:String) { return s.length; }" } };
+            var expectedConvertedContents = new[] { new SourceFile { FileName = "string_members.cs", Contents = DefaultGeneratedClass + $"string_members : MonoBehaviour {{ public virtual int F(string s) {{ return s.Length; }} }}" } };
+
+            AssertConversion(sourceFiles, expectedConvertedContents);
+        }
+
+        [Test]
         public void Test_Formatting()
         {
         }
@@ -840,6 +849,7 @@ namespace UnityScript2CSharp.Tests
                 "lock",
                 "nameof",
                 "namespace",
+                "object",
                 "operator",
                 "out",
                 "params",
@@ -849,11 +859,12 @@ namespace UnityScript2CSharp.Tests
                 "sealed",
                 "sizeof",
                 "stackalloc",
+                "string",
                 "struct",
                 "unchecked",
                 "unsafe",
                 "using",
-                "volatile"
+                "volatile",
             };
 
             foreach (var keyword in keywords)

--- a/UnityScript2CSharp/Program.cs
+++ b/UnityScript2CSharp/Program.cs
@@ -282,7 +282,7 @@ namespace UnityScript2CSharp
 
             try
             {
-                var found = Directory.GetFiles(testPath, "*.dll").Any(file => unityProbePathRegex.IsMatch(file));
+                var found = Directory.GetFiles(testPath, "*.dll").Any(MatchesUnityEngineInInstallationFolder);
                 if (found)
                 {
                     if (verbose)
@@ -306,6 +306,11 @@ namespace UnityScript2CSharp
 
             unityAssembliesRootPath = null;
             return false;
+        }
+
+        private static bool MatchesUnityEngineInInstallationFolder(string filePath)
+        {
+            return unityProbePathRegex.IsMatch(filePath) && !filePath.Contains("PlaybackEngines");
         }
 
         private static bool ValidateAssemblyReferences(ParserResult<CommandLineArguments> options)

--- a/UnityScript2CSharp/Program.cs
+++ b/UnityScript2CSharp/Program.cs
@@ -15,12 +15,16 @@ namespace UnityScript2CSharp
         static int Main(string[] args)
         {
             ParserResult<CommandLineArguments> options = null;
-
             try
             {
                 options = Parser.Default.ParseArguments<CommandLineArguments>(args);
+                RedirectConsoleOutput(options.Value.OutputFile);
+
                 if (!IsValid(options))
                     return -2;
+                
+                var assembly = typeof(Program).Assembly;
+                Console.WriteLine($"{assembly.GetName().Name} {assembly.GetName().Version}");
             }
             catch
             {
@@ -34,8 +38,6 @@ namespace UnityScript2CSharp
                 
                 return -3;
             }
-
-            RedirectConsoleOutput(options.Value.OutputFile);
 
             if (!ReadResponseFile(options.Value))
                 return -4;

--- a/UnityScript2CSharp/Steps/CSharpReservedKeywordIdentifierClashFix.cs
+++ b/UnityScript2CSharp/Steps/CSharpReservedKeywordIdentifierClashFix.cs
@@ -148,6 +148,7 @@ namespace UnityScript2CSharp.Steps
             "sealed",
             "sizeof",
             "stackalloc",
+            "string",
             "struct",
             "unchecked",
             "unsafe",

--- a/UnityScript2CSharp/Steps/PromoteImplicitBooleanConversionsToExplicitComparisons.cs
+++ b/UnityScript2CSharp/Steps/PromoteImplicitBooleanConversionsToExplicitComparisons.cs
@@ -159,11 +159,11 @@ namespace UnityScript2CSharp.Steps
         }
     }
 
-    // This visitor's reponsability is to take expressions like:
+    // This visitor's responsability is to take expressions like:
     //
     //          var b = s && s.Length > 10;
     //
-    // and converte them to:
+    // and convert them to:
     //          var b = !string.IsNullOrEmpty(s) ? s.Length > 10 : false;
     //
     // (note that US compiler already does part of this conversion; we only need

--- a/UnityScript2CSharp/UnityScript2CSharp.csproj
+++ b/UnityScript2CSharp/UnityScript2CSharp.csproj
@@ -142,7 +142,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Steps\RemoveUnnecessaryCastInArrayInstantiation.cs" />
-    <Compile Include="Steps\ReplaceArrayMemberReferenceWithCamelCaseVersion.cs" />
+    <Compile Include="Steps\ReplaceArrayAndStringMemberReferenceWithCamelCaseVersion.cs" />
     <Compile Include="SourceFile.cs" />
     <Compile Include="Steps\ReplaceUnityScriptArrayWithObjectArray.cs" />
     <Compile Include="Steps\SelectiveUnaryExpressionExpansionProcessUnityScriptMethods.cs" />

--- a/UnityScript2CSharp/UnityScript2CSharpConverter.cs
+++ b/UnityScript2CSharp/UnityScript2CSharpConverter.cs
@@ -227,7 +227,7 @@ namespace UnityScript2CSharp
             adjustedPipeline.Add(new RenameArrayDeclaration());
             adjustedPipeline.Add(new ReplaceUnityScriptArrayWithObjectArray());
             adjustedPipeline.Add(new InjectTypeOfExpressionsInArgumentsOfSystemType());
-            adjustedPipeline.Add(new ReplaceArrayMemberReferenceWithCamelCaseVersion());
+            adjustedPipeline.Add(new ReplaceArrayAndStringMemberReferenceWithCamelCaseVersion());
 
             adjustedPipeline.Add(new ReplaceGetSetItemMethodsWithOriginalIndexers());
             adjustedPipeline.Add(new PromoteImplicitBooleanConversionsToExplicitComparisons());

--- a/UnityScript2CSharp/UnityScript2CSharpConverterVisitor.cs
+++ b/UnityScript2CSharp/UnityScript2CSharpConverterVisitor.cs
@@ -1496,11 +1496,11 @@ namespace UnityScript2CSharp
             }
 
             var parameters = new StringBuilder();
-            var last = genericArgs.LastOrDefault();
-            foreach (var type in genericArgs)
+            var lastIndex = genericArgs.Count - 1;
+            for (int i = 0; i < genericArgs.Count; i++)
             {
-                parameters.Append(TypeNameFor(type));
-                if (type != last)
+                parameters.Append(TypeNameFor(genericArgs[i]));
+                if (i != lastIndex)
                     parameters.Append(",");
             }
 


### PR DESCRIPTION
Fixed issues :
- #51 
- #53

Also fixes an issue in which the converter would fail to find Unity root folder and would print:

> UnityScript2CSharp was not able to convert your project:.
>
> The version of Unity passed as the Unity Editor path is too old. Details: Could not find the module assembly folder.
>Consider running converter with '-i' option.
